### PR TITLE
Remove version string from game name

### DIFF
--- a/engine.cfg
+++ b/engine.cfg
@@ -1,6 +1,6 @@
 [application]
 
-name="Minilens 1.2-dev"
+name="Minilens"
 main_scene="res://scenes/main_menu.xml"
 icon="icon.png"
 boot_splash="res://KOBUGE_Splash.png"

--- a/scripts/global.gd
+++ b/scripts/global.gd
@@ -8,6 +8,7 @@ var current_scene
 var orig_size
 var viewport
 var is_first_load = true
+var version = 1.2
 
 func _ready():
 	root = get_tree().get_root()
@@ -16,6 +17,7 @@ func _ready():
 	orig_size = Vector2(1024,768)
 	viewport.connect("size_changed",self,"window_resize")
 	window_resize()
+	OS.set_window_title("Minilens - Version " + str(version))
 
 func window_resize():
 	var window_size = OS.get_window_size()


### PR DESCRIPTION
The game name (defined in engine.cfg is used to determine the user:// path,
so it is better to keep a constant game name. The version info is now given in the
window title.
